### PR TITLE
Fix for "RuntimeError: result type Float can't be cast to the desired output type long int"

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -219,7 +219,7 @@ class ComputeLoss:
 
             # Append
             a = t[:, 6].long()  # anchor indices
-            indices.append((b, a, gj.clamp_(0, gain[3] - 1), gi.clamp_(0, gain[2] - 1)))  # image, anchor, grid indices
+            indices.append((b, a, gj.clamp_(0, int(gain[3] - 1)), gi.clamp_(0, int(gain[2] - 1))))  # image, anchor, grid indices
             tbox.append(torch.cat((gxy - gij, gwh), 1))  # box
             anch.append(anchors[a])  # anchors
             tcls.append(c)  # class


### PR DESCRIPTION
Hello,
I tried this repo and got the following message when experimenting with yolov5 (I am using Pytorch 1.12.1 and python 3.10.6):

> Traceback (most recent call last):
>   File "/\*\*\*\*\*/yoloair/train.py", line 695, in <module>
>     main(opt)
>   File "/\*\*\*\*\*/yoloair/train.py", line 591, in main
>     train(opt.hyp, opt, device, callbacks)
>   File "/\*\*\*\*\*/yoloair/train.py", line 376, in train
>     loss, loss_items = compute_loss(pred, targets.to(device))  # loss scaled by batch_size
>   File "/\*\*\*\*\*/yoloair/utils/loss.py", line 123, in __call__
>     tcls, tbox, indices, anchors = self.build_targets(p, targets)  # targets
>   File "/\*\*\*\*\*/yoloair/utils/loss.py", line 222, in build_targets
>     indices.append((b, a, gj.clamp_(0, gain[3] - 1), gi.clamp_(0, gain[2] - 1)))  # image, anchor, grid indices
> RuntimeError: result type Float can't be cast to the desired output type long int

I fixed it by casting from Float to Int:
`indices.append((b, a, gj.clamp_(0, int(gain[3] - 1)), gi.clamp_(0, int(gain[2] - 1))))`

I figured that this could save some time to people getting the same issue.