### PR TITLE
Fix for "RuntimeError: result type Float can't be cast to the desired output type long int"

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -186,8 +186,8 @@ class ComputeLoss:
                             ], device=targets.device).float() * g  # offsets
 
         for i in range(self.nl):
-            anchors = self.anchors[i]
-            gain[2:6] = torch.tensor(p[i].shape)[[3, 2, 3, 2]]  # xyxy gain
+            anchors, shape = self.anchors[i], p[i].shape
+            gain[2:6] = torch.tensor(shape)[[3, 2, 3, 2]] # xyxy gain
 
             # Match targets to anchors
             t = targets * gain
@@ -219,7 +219,7 @@ class ComputeLoss:
 
             # Append
             a = t[:, 6].long()  # anchor indices
-            indices.append((b, a, gj.clamp_(0, gain[3] - 1), gi.clamp_(0, gain[2] - 1)))  # image, anchor, grid indices
+            indices.append((b, a, gj.clamp_(0, shape[2] - 1), gi.clamp_(0, shape[3] - 1)))  # image, anchor, grid indices
             tbox.append(torch.cat((gxy - gij, gwh), 1))  # box
             anch.append(anchors[a])  # anchors
             tcls.append(c)  # class


### PR DESCRIPTION
Hello,
This pull request is the result of [this conversation](https://github.com/iscyy/yoloair/pull/48).
I adapted the code based on [this fix from the official Yolov5 repository](https://github.com/ultralytics/yolov5/pull/8067/commits/bfb3e19c6b421b5a5292e94c71a1940f1235c9c8#diff-afc9c0f856a1fa54a2d35dfcd375a176b7b736953195238a3a51870eef4314bb).
I tried it locally and it solved the issue for me.